### PR TITLE
Fixed payload request for CoinPaymentsCreateMassWithdrawalRequest.

### DIFF
--- a/src/main/java/org/brunocvcunha/coinpayments/model/CreateWithdrawalResponse.java
+++ b/src/main/java/org/brunocvcunha/coinpayments/model/CreateWithdrawalResponse.java
@@ -17,9 +17,14 @@ package org.brunocvcunha.coinpayments.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
+@EqualsAndHashCode(callSuper = true)
+@Data
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CreateWithdrawalResponse extends CreateTransferResponse {
 
     private double amount;
+    private String error;
+    private String note;
 }

--- a/src/main/java/org/brunocvcunha/coinpayments/requests/CoinPaymentsCreateMassWithdrawalRequest.java
+++ b/src/main/java/org/brunocvcunha/coinpayments/requests/CoinPaymentsCreateMassWithdrawalRequest.java
@@ -28,11 +28,11 @@ import org.brunocvcunha.coinpayments.requests.base.CoinPaymentsPostRequest;
 @RequiredArgsConstructor
 @Data
 @Builder
+@EqualsAndHashCode(callSuper = true)
 public class CoinPaymentsCreateMassWithdrawalRequest extends CoinPaymentsPostRequest<ResponseWrapper<Map<String, CreateWithdrawalResponse>>> {
 
     @NonNull
     private List<Map<String, String>> wd;
-
 
     @Override
     public String getUrl () {
@@ -41,7 +41,14 @@ public class CoinPaymentsCreateMassWithdrawalRequest extends CoinPaymentsPostReq
 
     @Override
     public String getPayload () {
-        return "cmd=create_mass_withdrawal" + "&wd=" + wd;
+        StringBuilder sb = new StringBuilder();
+        for(int i = 0; i < wd.size(); i++){
+            Map<String, String> entries = wd.get(i);
+            for(Map.Entry<String, String> entry : entries.entrySet()) {
+                sb.append("&wd[wd").append(i).append("][").append(entry.getKey()).append("]").append("=").append(entry.getValue());
+            }
+        }
+        return "cmd=create_mass_withdrawal" + sb.toString();
     }
 
     @Override

--- a/src/main/java/org/brunocvcunha/coinpayments/requests/base/CoinPaymentsPostRequest.java
+++ b/src/main/java/org/brunocvcunha/coinpayments/requests/base/CoinPaymentsPostRequest.java
@@ -19,6 +19,8 @@ import java.io.IOException;
 
 import javax.crypto.Mac;
 
+import lombok.Data;
+import lombok.EqualsAndHashCode;
 import org.apache.commons.codec.digest.HmacAlgorithms;
 import org.apache.commons.codec.digest.HmacUtils;
 import org.apache.http.HttpResponse;
@@ -35,6 +37,8 @@ import lombok.extern.log4j.Log4j;
  * @author brunovolpato
  *
  */
+@Data
+@EqualsAndHashCode(callSuper = true)
 @Log4j
 public abstract class CoinPaymentsPostRequest<T> extends CoinPaymentsRequest<T> {
 

--- a/src/main/java/org/brunocvcunha/coinpayments/requests/base/CoinPaymentsRequest.java
+++ b/src/main/java/org/brunocvcunha/coinpayments/requests/base/CoinPaymentsRequest.java
@@ -18,6 +18,7 @@ package org.brunocvcunha.coinpayments.requests.base;
 import java.io.IOException;
 import java.io.InputStream;
 
+import lombok.*;
 import org.apache.http.client.ClientProtocolException;
 import org.brunocvcunha.coinpayments.CoinPayments;
 import org.brunocvcunha.inutils4j.MyStreamUtils;
@@ -26,15 +27,11 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.SneakyThrows;
 import lombok.extern.log4j.Log4j;
 
 @AllArgsConstructor
 @NoArgsConstructor
+@EqualsAndHashCode
 @Log4j
 public abstract class CoinPaymentsRequest<T> {
 


### PR DESCRIPTION
The CoinPaymentsCreateMassWithdrawalRequest was not working with the current API. These changes should fix the mass withdrawal requests.