### PR TITLE
Throw JsonProcessingException explicitly on parse response

### DIFF
--- a/src/main/java/org/brunocvcunha/coinpayments/requests/CoinPaymentsBalancesRequest.java
+++ b/src/main/java/org/brunocvcunha/coinpayments/requests/CoinPaymentsBalancesRequest.java
@@ -17,6 +17,7 @@ package org.brunocvcunha.coinpayments.requests;
 
 import java.util.Map;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.brunocvcunha.coinpayments.model.BalanceResponse;
 import org.brunocvcunha.coinpayments.model.ResponseWrapper;
 import org.brunocvcunha.coinpayments.requests.base.CoinPaymentsPostRequest;
@@ -52,7 +53,7 @@ public class CoinPaymentsBalancesRequest extends CoinPaymentsPostRequest<Respons
     }
 
 	@Override
-	public ResponseWrapper<Map<String, BalanceResponse>> parseResult(int resultCode, String content) {
+	public ResponseWrapper<Map<String, BalanceResponse>> parseResult(int resultCode, String content) throws JsonProcessingException {
 		System.out.println(content);
         ResponseWrapper<Map<String, BalanceResponse>> wrapper = parseJson(content, new TypeReference<ResponseWrapper<Map<String, BalanceResponse>>>() {});
         return wrapper;

--- a/src/main/java/org/brunocvcunha/coinpayments/requests/CoinPaymentsBasicAccountInfoRequest.java
+++ b/src/main/java/org/brunocvcunha/coinpayments/requests/CoinPaymentsBasicAccountInfoRequest.java
@@ -15,16 +15,13 @@
  */
 package org.brunocvcunha.coinpayments.requests;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
-
+import lombok.SneakyThrows;
 import org.brunocvcunha.coinpayments.model.BasicInfoResponse;
 import org.brunocvcunha.coinpayments.model.ResponseWrapper;
 import org.brunocvcunha.coinpayments.requests.base.CoinPaymentsPostRequest;
-
-import com.fasterxml.jackson.core.type.TypeReference;
-
-import lombok.SneakyThrows;
 
 /**
  * Search GIFs Request
@@ -52,9 +49,6 @@ public class CoinPaymentsBasicAccountInfoRequest extends CoinPaymentsPostRequest
     @SneakyThrows
     public ResponseWrapper<BasicInfoResponse> parseResult(int statusCode, String content) {
         ResponseWrapper<BasicInfoResponse> wrapper = parseJson(content, new TypeReference<ResponseWrapper<BasicInfoResponse>>() {});
-
-        //ResponseWrapper<BasicInfoResponse> wrapper = parseJson(content, ResponseWrapper.class);
-        //wrapper.setResult(parseJson(new ObjectMapper().writeValueAsString(wrapper.getResult()), BasicInfoResponse.class)); //?j
         return wrapper;
     }
 

--- a/src/main/java/org/brunocvcunha/coinpayments/requests/CoinPaymentsClaimTagRequest.java
+++ b/src/main/java/org/brunocvcunha/coinpayments/requests/CoinPaymentsClaimTagRequest.java
@@ -17,6 +17,7 @@ package org.brunocvcunha.coinpayments.requests;
 
 import java.util.List;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.brunocvcunha.coinpayments.model.ClaimTagResponse;
 import org.brunocvcunha.coinpayments.model.ResponseWrapper;
 import org.brunocvcunha.coinpayments.requests.base.CoinPaymentsPostRequest;
@@ -51,7 +52,7 @@ public class CoinPaymentsClaimTagRequest extends CoinPaymentsPostRequest<Respons
     }
 
 	@Override
-	public ResponseWrapper<List<ClaimTagResponse>> parseResult(int resultCode, String content) {
+	public ResponseWrapper<List<ClaimTagResponse>> parseResult(int resultCode, String content) throws JsonProcessingException {
         ResponseWrapper<List<ClaimTagResponse>> wrapper = parseJson(content, new TypeReference<ResponseWrapper<List<ClaimTagResponse>>>() {});
         return wrapper;
 	}

--- a/src/main/java/org/brunocvcunha/coinpayments/requests/CoinPaymentsConversionLimitsRequest.java
+++ b/src/main/java/org/brunocvcunha/coinpayments/requests/CoinPaymentsConversionLimitsRequest.java
@@ -15,6 +15,7 @@
  */
 package org.brunocvcunha.coinpayments.requests;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.brunocvcunha.coinpayments.model.ConversionLimitsResponse;
 import org.brunocvcunha.coinpayments.model.ResponseWrapper;
 import org.brunocvcunha.coinpayments.requests.base.CoinPaymentsPostRequest;
@@ -48,7 +49,7 @@ public class CoinPaymentsConversionLimitsRequest extends CoinPaymentsPostRequest
     }
 
 	@Override
-	public ResponseWrapper<ConversionLimitsResponse> parseResult(int resultCode, String content) {
+	public ResponseWrapper<ConversionLimitsResponse> parseResult(int resultCode, String content) throws JsonProcessingException {
 		ResponseWrapper<ConversionLimitsResponse> wrapper = parseJson( content, new TypeReference<ResponseWrapper<ConversionLimitsResponse>>() {} );
         return wrapper;
 	}

--- a/src/main/java/org/brunocvcunha/coinpayments/requests/CoinPaymentsConvertCoinsRequest.java
+++ b/src/main/java/org/brunocvcunha/coinpayments/requests/CoinPaymentsConvertCoinsRequest.java
@@ -15,6 +15,7 @@
  */
 package org.brunocvcunha.coinpayments.requests;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.brunocvcunha.coinpayments.model.ConvertCoinResponse;
 import org.brunocvcunha.coinpayments.model.ResponseWrapper;
 import org.brunocvcunha.coinpayments.requests.base.CoinPaymentsPostRequest;
@@ -55,7 +56,7 @@ public class CoinPaymentsConvertCoinsRequest extends CoinPaymentsPostRequest<Res
     }
 
 	@Override
-	public ResponseWrapper<ConvertCoinResponse> parseResult ( int resultCode, String content ) {
+	public ResponseWrapper<ConvertCoinResponse> parseResult ( int resultCode, String content ) throws JsonProcessingException {
 		ResponseWrapper<ConvertCoinResponse> wrapper = parseJson( content, new TypeReference<ResponseWrapper<ConvertCoinResponse>>() {} );
         return wrapper;
 	}

--- a/src/main/java/org/brunocvcunha/coinpayments/requests/CoinPaymentsCreateMassWithdrawalRequest.java
+++ b/src/main/java/org/brunocvcunha/coinpayments/requests/CoinPaymentsCreateMassWithdrawalRequest.java
@@ -15,6 +15,7 @@
  */
 package org.brunocvcunha.coinpayments.requests;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import lombok.*;
 
@@ -52,7 +53,7 @@ public class CoinPaymentsCreateMassWithdrawalRequest extends CoinPaymentsPostReq
     }
 
     @Override
-    public ResponseWrapper<Map<String, CreateWithdrawalResponse>> parseResult ( int resultCode, String content ) {
+    public ResponseWrapper<Map<String, CreateWithdrawalResponse>> parseResult ( int resultCode, String content ) throws JsonProcessingException {
     	ResponseWrapper<Map<String, CreateWithdrawalResponse>> wrapper = parseJson( content, new TypeReference<ResponseWrapper<Map<String, CreateWithdrawalResponse>>>() {});
         return wrapper;
     }

--- a/src/main/java/org/brunocvcunha/coinpayments/requests/CoinPaymentsCreateTransactionRequest.java
+++ b/src/main/java/org/brunocvcunha/coinpayments/requests/CoinPaymentsCreateTransactionRequest.java
@@ -15,19 +15,13 @@
  */
 package org.brunocvcunha.coinpayments.requests;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import lombok.*;
 import lombok.extern.log4j.Log4j;
 import org.brunocvcunha.coinpayments.model.CreateTransactionResponse;
 import org.brunocvcunha.coinpayments.model.ResponseWrapper;
 import org.brunocvcunha.coinpayments.requests.base.CoinPaymentsPostRequest;
-
-import com.fasterxml.jackson.core.type.TypeReference;
-
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.SneakyThrows;
 
 /**
  * CoinPaymentsCreateTransactionRequest
@@ -69,7 +63,6 @@ public class CoinPaymentsCreateTransactionRequest
     }
 
     @Override
-    @SneakyThrows
     public String getPayload() {
         return "cmd=create_transaction" + "&amount=" + amount + "" + "&currency1=" + currencyPrice + "&currency2="
                 + currencyTransfer + "&address=" + address + "&buyer_email=" + buyerEmail + "&buyer_name=" + buyerName
@@ -78,8 +71,7 @@ public class CoinPaymentsCreateTransactionRequest
     }
 
     @Override
-    @SneakyThrows
-    public ResponseWrapper<CreateTransactionResponse> parseResult(int statusCode, String content) {
+    public ResponseWrapper<CreateTransactionResponse> parseResult(int statusCode, String content) throws JsonProcessingException {
         log.debug("parsing CreateTransactionResponse:  "+ content + ", statusCode: " + statusCode);
         ResponseWrapper<CreateTransactionResponse> wrapper = parseJson(content,
                 new TypeReference<ResponseWrapper<CreateTransactionResponse>>() {

--- a/src/main/java/org/brunocvcunha/coinpayments/requests/CoinPaymentsCreateTransferRequest.java
+++ b/src/main/java/org/brunocvcunha/coinpayments/requests/CoinPaymentsCreateTransferRequest.java
@@ -15,6 +15,7 @@
  */
 package org.brunocvcunha.coinpayments.requests;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.brunocvcunha.coinpayments.model.CreateTransferResponse;
 import org.brunocvcunha.coinpayments.model.ResponseWrapper;
 import org.brunocvcunha.coinpayments.requests.base.CoinPaymentsPostRequest;
@@ -60,7 +61,7 @@ public class CoinPaymentsCreateTransferRequest extends CoinPaymentsPostRequest<R
     }
 
 	@Override
-	public ResponseWrapper<CreateTransferResponse> parseResult(int resultCode, String content) {
+	public ResponseWrapper<CreateTransferResponse> parseResult(int resultCode, String content) throws JsonProcessingException {
         ResponseWrapper<CreateTransferResponse> wrapper = parseJson( content, new TypeReference<ResponseWrapper<CreateTransferResponse>>() {} );
         return wrapper;
 	}

--- a/src/main/java/org/brunocvcunha/coinpayments/requests/CoinPaymentsCreateWithdrawalRequest.java
+++ b/src/main/java/org/brunocvcunha/coinpayments/requests/CoinPaymentsCreateWithdrawalRequest.java
@@ -15,6 +15,7 @@
  */
 package org.brunocvcunha.coinpayments.requests;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import lombok.*;
 import org.brunocvcunha.coinpayments.model.CreateWithdrawalResponse;
@@ -56,7 +57,7 @@ public class CoinPaymentsCreateWithdrawalRequest extends CoinPaymentsPostRequest
     }
 
     @Override
-    public ResponseWrapper<CreateWithdrawalResponse> parseResult ( int resultCode, String content ) {
+    public ResponseWrapper<CreateWithdrawalResponse> parseResult ( int resultCode, String content ) throws JsonProcessingException {
         ResponseWrapper<CreateWithdrawalResponse> wrapper = parseJson( content, new TypeReference<ResponseWrapper<CreateWithdrawalResponse>>() {} );
         return wrapper;
     }

--- a/src/main/java/org/brunocvcunha/coinpayments/requests/CoinPaymentsDepositRequest.java
+++ b/src/main/java/org/brunocvcunha/coinpayments/requests/CoinPaymentsDepositRequest.java
@@ -15,6 +15,7 @@
  */
 package org.brunocvcunha.coinpayments.requests;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -41,7 +42,7 @@ public class CoinPaymentsDepositRequest extends CoinPaymentsPostRequest<Response
     }
 
     @Override
-    public ResponseWrapper<AddressResponse> parseResult ( int resultCode, String content ) {
+    public ResponseWrapper<AddressResponse> parseResult ( int resultCode, String content ) throws JsonProcessingException {
         ResponseWrapper<AddressResponse> wrapper = parseJson( content, new TypeReference<ResponseWrapper<AddressResponse>>() {} );
         return wrapper;
     }

--- a/src/main/java/org/brunocvcunha/coinpayments/requests/CoinPaymentsGetCallbackAddressRequest.java
+++ b/src/main/java/org/brunocvcunha/coinpayments/requests/CoinPaymentsGetCallbackAddressRequest.java
@@ -15,6 +15,7 @@
  */
 package org.brunocvcunha.coinpayments.requests;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import lombok.*;
 import org.brunocvcunha.coinpayments.model.AddressResponse;
@@ -43,7 +44,7 @@ public class CoinPaymentsGetCallbackAddressRequest extends CoinPaymentsPostReque
     }
 
     @Override
-    public ResponseWrapper<AddressResponse> parseResult ( int resultCode, String content ) {
+    public ResponseWrapper<AddressResponse> parseResult ( int resultCode, String content ) throws JsonProcessingException {
         ResponseWrapper<AddressResponse> wrapper = parseJson( content, new TypeReference<ResponseWrapper<AddressResponse>>() {} );
         return wrapper;
     }

--- a/src/main/java/org/brunocvcunha/coinpayments/requests/CoinPaymentsGetConversionInfoRequest.java
+++ b/src/main/java/org/brunocvcunha/coinpayments/requests/CoinPaymentsGetConversionInfoRequest.java
@@ -15,6 +15,7 @@
  */
 package org.brunocvcunha.coinpayments.requests;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.brunocvcunha.coinpayments.model.GetConversionInfoResponse;
 import org.brunocvcunha.coinpayments.model.ResponseWrapper;
 import org.brunocvcunha.coinpayments.requests.base.CoinPaymentsPostRequest;
@@ -46,7 +47,7 @@ public class CoinPaymentsGetConversionInfoRequest
     }
 
 	@Override
-	public ResponseWrapper<GetConversionInfoResponse> parseResult(int resultCode, String content) {
+	public ResponseWrapper<GetConversionInfoResponse> parseResult(int resultCode, String content) throws JsonProcessingException {
         ResponseWrapper<GetConversionInfoResponse> wrapper = parseJson(content,
                 new TypeReference<ResponseWrapper<GetConversionInfoResponse>>() {
                 });

--- a/src/main/java/org/brunocvcunha/coinpayments/requests/CoinPaymentsGetMultiTransactionInfoRequest.java
+++ b/src/main/java/org/brunocvcunha/coinpayments/requests/CoinPaymentsGetMultiTransactionInfoRequest.java
@@ -18,6 +18,7 @@ package org.brunocvcunha.coinpayments.requests;
 import java.util.Arrays;
 import java.util.List;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.brunocvcunha.coinpayments.model.ResponseWrapper;
 import org.brunocvcunha.coinpayments.model.TransactionDetailsResponse;
 import org.brunocvcunha.coinpayments.requests.base.CoinPaymentsPostRequest;
@@ -51,7 +52,7 @@ public class CoinPaymentsGetMultiTransactionInfoRequest extends CoinPaymentsPost
     }
 
 	@Override
-	public ResponseWrapper<List<TransactionDetailsResponse>> parseResult(int resultCode, String content) {
+	public ResponseWrapper<List<TransactionDetailsResponse>> parseResult(int resultCode, String content) throws JsonProcessingException {
         ResponseWrapper<List<TransactionDetailsResponse>> wrapper = parseJson(content,
                 new TypeReference<ResponseWrapper<List<TransactionDetailsResponse>>>() {
                 });

--- a/src/main/java/org/brunocvcunha/coinpayments/requests/CoinPaymentsGetProfileInfoRequest.java
+++ b/src/main/java/org/brunocvcunha/coinpayments/requests/CoinPaymentsGetProfileInfoRequest.java
@@ -15,6 +15,7 @@
  */
 package org.brunocvcunha.coinpayments.requests;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.brunocvcunha.coinpayments.model.GetConversionInfoResponse;
 import org.brunocvcunha.coinpayments.model.GetProfileInfoResponse;
 import org.brunocvcunha.coinpayments.model.ResponseWrapper;
@@ -46,7 +47,7 @@ public class CoinPaymentsGetProfileInfoRequest extends CoinPaymentsPostRequest<R
     }
 
 	@Override
-	public ResponseWrapper<GetProfileInfoResponse> parseResult(int resultCode, String content) {
+	public ResponseWrapper<GetProfileInfoResponse> parseResult(int resultCode, String content) throws JsonProcessingException {
         ResponseWrapper<GetProfileInfoResponse> wrapper = parseJson(content, new TypeReference<ResponseWrapper<GetProfileInfoResponse>>() {});
         return wrapper;
 	}

--- a/src/main/java/org/brunocvcunha/coinpayments/requests/CoinPaymentsGetTagListRequest.java
+++ b/src/main/java/org/brunocvcunha/coinpayments/requests/CoinPaymentsGetTagListRequest.java
@@ -17,6 +17,7 @@ package org.brunocvcunha.coinpayments.requests;
 
 import java.util.List;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.brunocvcunha.coinpayments.model.GetTagListResponse;
 import org.brunocvcunha.coinpayments.model.ResponseWrapper;
 import org.brunocvcunha.coinpayments.requests.base.CoinPaymentsPostRequest;
@@ -41,7 +42,7 @@ public class CoinPaymentsGetTagListRequest extends CoinPaymentsPostRequest<Respo
     }
 
 	@Override
-	public ResponseWrapper<List<GetTagListResponse>> parseResult(int resultCode, String content) {
+	public ResponseWrapper<List<GetTagListResponse>> parseResult(int resultCode, String content) throws JsonProcessingException {
         ResponseWrapper<List<GetTagListResponse>> wrapper = parseJson(content, new TypeReference<ResponseWrapper<List<GetTagListResponse>>>() {});
         return wrapper;		
 	}

--- a/src/main/java/org/brunocvcunha/coinpayments/requests/CoinPaymentsGetTransactionInfoRequest.java
+++ b/src/main/java/org/brunocvcunha/coinpayments/requests/CoinPaymentsGetTransactionInfoRequest.java
@@ -15,12 +15,15 @@
  */
 package org.brunocvcunha.coinpayments.requests;
 
-import lombok.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
 import org.brunocvcunha.coinpayments.model.ResponseWrapper;
 import org.brunocvcunha.coinpayments.model.TransactionDetailsResponse;
 import org.brunocvcunha.coinpayments.requests.base.CoinPaymentsPostRequest;
-
-import com.fasterxml.jackson.core.type.TypeReference;
 
 /**
  * CoinPaymentsCreateTransactionRequest
@@ -43,14 +46,12 @@ public class CoinPaymentsGetTransactionInfoRequest
     }
 
     @Override
-    @SneakyThrows
     public String getPayload() {
         return "cmd=get_tx_info&txid=" + txid + "&full=1";
     }
 
     @Override
-    @SneakyThrows
-    public ResponseWrapper<TransactionDetailsResponse> parseResult(int statusCode, String content) {
+    public ResponseWrapper<TransactionDetailsResponse> parseResult(int statusCode, String content) throws JsonProcessingException {
         ResponseWrapper<TransactionDetailsResponse> wrapper = parseJson(content,
                 new TypeReference<ResponseWrapper<TransactionDetailsResponse>>() {
                 });

--- a/src/main/java/org/brunocvcunha/coinpayments/requests/CoinPaymentsGetTransactionListRequest.java
+++ b/src/main/java/org/brunocvcunha/coinpayments/requests/CoinPaymentsGetTransactionListRequest.java
@@ -15,6 +15,7 @@
  */
 package org.brunocvcunha.coinpayments.requests;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import lombok.*;
 import org.brunocvcunha.coinpayments.model.ResponseWrapper;
@@ -47,7 +48,7 @@ public class CoinPaymentsGetTransactionListRequest extends CoinPaymentsPostReque
     }
 
     @Override
-    public ResponseWrapper<List<String>> parseResult ( int resultCode, String content ) {
+    public ResponseWrapper<List<String>> parseResult ( int resultCode, String content ) throws JsonProcessingException {
         ResponseWrapper<List<String>> wrapper = parseJson( content, new TypeReference<ResponseWrapper<List<String>>>() {} );
         return wrapper;
     }

--- a/src/main/java/org/brunocvcunha/coinpayments/requests/CoinPaymentsGetWithdrawalHistoryRequest.java
+++ b/src/main/java/org/brunocvcunha/coinpayments/requests/CoinPaymentsGetWithdrawalHistoryRequest.java
@@ -17,6 +17,7 @@ package org.brunocvcunha.coinpayments.requests;
 
 import java.util.Map;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.brunocvcunha.coinpayments.model.ResponseWrapper;
 import org.brunocvcunha.coinpayments.model.WithdrawalHistoryResponse;
 import org.brunocvcunha.coinpayments.requests.base.CoinPaymentsPostRequest;
@@ -45,7 +46,7 @@ public class CoinPaymentsGetWithdrawalHistoryRequest extends CoinPaymentsPostReq
     }
 
 	@Override
-	public ResponseWrapper<Map<String, WithdrawalHistoryResponse>> parseResult(int resultCode, String content) {
+	public ResponseWrapper<Map<String, WithdrawalHistoryResponse>> parseResult(int resultCode, String content) throws JsonProcessingException {
         ResponseWrapper<Map<String, WithdrawalHistoryResponse>> wrapper = parseJson(content, new TypeReference<ResponseWrapper<Map<String, WithdrawalHistoryResponse>>>() {});
         return wrapper;
 	}

--- a/src/main/java/org/brunocvcunha/coinpayments/requests/CoinPaymentsGetWithdrawalInfoRequest.java
+++ b/src/main/java/org/brunocvcunha/coinpayments/requests/CoinPaymentsGetWithdrawalInfoRequest.java
@@ -15,6 +15,7 @@
  */
 package org.brunocvcunha.coinpayments.requests;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.brunocvcunha.coinpayments.model.ResponseWrapper;
 import org.brunocvcunha.coinpayments.model.WithdrawalInfoResponse;
 import org.brunocvcunha.coinpayments.requests.CoinPaymentsGetTransactionInfoRequest.CoinPaymentsGetTransactionInfoRequestBuilder;
@@ -47,7 +48,7 @@ public class CoinPaymentsGetWithdrawalInfoRequest  extends CoinPaymentsPostReque
     }
 
 	@Override
-	public ResponseWrapper<WithdrawalInfoResponse> parseResult(int resultCode, String content) {
+	public ResponseWrapper<WithdrawalInfoResponse> parseResult(int resultCode, String content) throws JsonProcessingException {
         ResponseWrapper<WithdrawalInfoResponse> wrapper = parseJson(content, new TypeReference<ResponseWrapper<WithdrawalInfoResponse>>() {});
         return wrapper;
 	}

--- a/src/main/java/org/brunocvcunha/coinpayments/requests/CoinPaymentsRatesRequest.java
+++ b/src/main/java/org/brunocvcunha/coinpayments/requests/CoinPaymentsRatesRequest.java
@@ -15,14 +15,17 @@
  */
 package org.brunocvcunha.coinpayments.requests;
 
-import java.util.Map;
-
-import lombok.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
 import org.brunocvcunha.coinpayments.model.RateResponse;
 import org.brunocvcunha.coinpayments.model.ResponseWrapper;
 import org.brunocvcunha.coinpayments.requests.base.CoinPaymentsPostRequest;
 
-import com.fasterxml.jackson.core.type.TypeReference;
+import java.util.Map;
 
 /**
  * Search GIFs Request
@@ -46,15 +49,13 @@ public class CoinPaymentsRatesRequest extends CoinPaymentsPostRequest<ResponseWr
     }
     
     @Override
-    @SneakyThrows
     public String getPayload() {
         return "cmd=rates&accepted=" + (onlyAccepted ? "1" : "0") + "&short=" + (onlyShort ? "1" : "0");
     }
 
 
     @Override
-    @SneakyThrows
-    public ResponseWrapper<Map<String, RateResponse>> parseResult(int statusCode, String content) {
+    public ResponseWrapper<Map<String, RateResponse>> parseResult(int statusCode, String content) throws JsonProcessingException {
         ResponseWrapper<Map<String, RateResponse>> wrapper = parseJson(content, new TypeReference<ResponseWrapper<Map<String, RateResponse>>>() {});
         return wrapper;
     }

--- a/src/main/java/org/brunocvcunha/coinpayments/requests/CoinPaymentsUpdateTagProfileRequest.java
+++ b/src/main/java/org/brunocvcunha/coinpayments/requests/CoinPaymentsUpdateTagProfileRequest.java
@@ -17,6 +17,7 @@ package org.brunocvcunha.coinpayments.requests;
 
 import java.util.List;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.brunocvcunha.coinpayments.model.ResponseWrapper;
 import org.brunocvcunha.coinpayments.model.UpdateTagProfileResponse;
 import org.brunocvcunha.coinpayments.requests.base.CoinPaymentsPostRequest;
@@ -61,7 +62,7 @@ public class CoinPaymentsUpdateTagProfileRequest extends CoinPaymentsPostRequest
     }
 
 	@Override
-	public ResponseWrapper<List<UpdateTagProfileResponse>> parseResult(int resultCode, String content) {
+	public ResponseWrapper<List<UpdateTagProfileResponse>> parseResult(int resultCode, String content) throws JsonProcessingException {
         ResponseWrapper<List<UpdateTagProfileResponse>> wrapper = parseJson(content, new TypeReference<ResponseWrapper<List<UpdateTagProfileResponse>>>() {});
         return wrapper;
 	}

--- a/src/main/java/org/brunocvcunha/coinpayments/requests/base/CoinPaymentsRequest.java
+++ b/src/main/java/org/brunocvcunha/coinpayments/requests/base/CoinPaymentsRequest.java
@@ -18,6 +18,7 @@ package org.brunocvcunha.coinpayments.requests.base;
 import java.io.IOException;
 import java.io.InputStream;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.*;
 import org.apache.http.client.ClientProtocolException;
 import org.brunocvcunha.coinpayments.CoinPayments;
@@ -72,7 +73,7 @@ public abstract class CoinPaymentsRequest<T> {
      * @param content
      *            Content
      */
-    public abstract T parseResult(int resultCode, String content);
+    public abstract T parseResult(int resultCode, String content) throws JsonProcessingException;
 
     /**
      * Parses Json into type
@@ -84,7 +85,7 @@ public abstract class CoinPaymentsRequest<T> {
      * @return Result
      */
     @SneakyThrows
-    public <U> U parseJson(String str, Class<U> clazz) {
+    public <U> U parseJson(String str, Class<U> clazz) throws JsonProcessingException {
         log.trace("Reading " + clazz.getSimpleName() + " from " + str);
         return new ObjectMapper().readValue(str, clazz);
     }
@@ -99,7 +100,7 @@ public abstract class CoinPaymentsRequest<T> {
      * @return Result
      */
     @SneakyThrows
-    public <U> U parseJson(String str, TypeReference<T> type) {
+    public <U> U parseJson(String str, TypeReference<T> type) throws JsonProcessingException {
         log.trace("Reading " + type.getType() + " from " + str);
         return new ObjectMapper().readValue(str, type);
     }
@@ -114,7 +115,7 @@ public abstract class CoinPaymentsRequest<T> {
      * @return Result
      */
     @SneakyThrows
-    public T parseJson(InputStream is, Class<T> clazz) {
+    public T parseJson(InputStream is, Class<T> clazz) throws JsonProcessingException {
         return this.parseJson(MyStreamUtils.readContent(is), clazz);
     }
 

--- a/src/test/java/org/brunocvcunha/coinpayments/CoinPaymentsCreateWithdrawalRequestTest.java
+++ b/src/test/java/org/brunocvcunha/coinpayments/CoinPaymentsCreateWithdrawalRequestTest.java
@@ -1,0 +1,31 @@
+package org.brunocvcunha.coinpayments;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.brunocvcunha.coinpayments.model.CreateWithdrawalResponse;
+import org.brunocvcunha.coinpayments.model.ResponseWrapper;
+import org.brunocvcunha.coinpayments.requests.CoinPaymentsCreateWithdrawalRequest;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class CoinPaymentsCreateWithdrawalRequestTest {
+    @Test(expected = JsonProcessingException.class)
+    public void throwJsonProcessingExceptionOnParsingError() throws JsonProcessingException {
+        final CoinPaymentsCreateWithdrawalRequest request =
+                new CoinPaymentsCreateWithdrawalRequest(0.0, "BTC", "fake_address");
+        request.parseResult(500, "{\"error\":\"That amount is larger than your balance!\",\"result\":[]}");
+    }
+
+    @Test
+    public void successfullyOkResponseToResponseObject() throws JsonProcessingException {
+        final CoinPaymentsCreateWithdrawalRequest request =
+                new CoinPaymentsCreateWithdrawalRequest(0.0, "BTC", "fake_address");
+        final String content = "{" +
+                "\"error\":\"That amount is larger than your balance!\"," +
+                "\"result\":{\"id\": \"fake_id\", \"status\": 200,\"amount\": 1.0, \"error\": \"ok\", \"note\": \"note\"}" +
+                "}";
+        final ResponseWrapper<CreateWithdrawalResponse> response = request.parseResult(200, content);
+        assertNotNull(response);
+        assertNotNull(response.getResult());
+    }
+}


### PR DESCRIPTION
I try to resolve this issue #6 , but found too complex to return error message from Coinpayments, I think it's possible in the only way to refuse generics

Which way decided to throw JsonProcessingException explicitly with parsing response up to execute() method