### PR TITLE
security: migrate from log4j 1.x to SLF4J/Logback

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,8 @@
 		<google.errorprone.version>2.0.9</google.errorprone.version>
 		<java.version>1.8</java.version>
 		<junit.version>4.13.1</junit.version>
-		<log4j.version>1.2.17</log4j.version>
+		<slf4j.version>2.0.16</slf4j.version>
+		<logback.version>1.5.16</logback.version>
 	</properties>
 
 	<distributionManagement>
@@ -176,9 +177,15 @@
 		</dependency>
 
 		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-			<version>${log4j.version}</version>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>${slf4j.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<version>${logback.version}</version>
 		</dependency>
 
 		<!-- Lombok -->

--- a/src/main/java/org/brunocvcunha/coinpayments/CoinPayments.java
+++ b/src/main/java/org/brunocvcunha/coinpayments/CoinPayments.java
@@ -21,13 +21,12 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
-import org.apache.log4j.Level;
 import org.brunocvcunha.coinpayments.requests.base.CoinPaymentsRequest;
 
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
-import lombok.extern.log4j.Log4j;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * 
@@ -37,12 +36,8 @@ import lombok.extern.log4j.Log4j;
  *
  */
 @Builder
-@Log4j
+@Slf4j
 public class CoinPayments {
-
-    static {
-        log.setLevel( Level.WARN );
-    }
 
     @Getter
     @Setter

--- a/src/main/java/org/brunocvcunha/coinpayments/requests/CoinPaymentsCreateTransactionRequest.java
+++ b/src/main/java/org/brunocvcunha/coinpayments/requests/CoinPaymentsCreateTransactionRequest.java
@@ -15,7 +15,7 @@
  */
 package org.brunocvcunha.coinpayments.requests;
 
-import lombok.extern.log4j.Log4j;
+import lombok.extern.slf4j.Slf4j;
 import org.brunocvcunha.coinpayments.model.CreateTransactionResponse;
 import org.brunocvcunha.coinpayments.model.ResponseWrapper;
 import org.brunocvcunha.coinpayments.requests.base.CoinPaymentsPostRequest;
@@ -39,7 +39,7 @@ import lombok.SneakyThrows;
 @AllArgsConstructor
 @Data
 @Builder
-@Log4j
+@Slf4j
 public class CoinPaymentsCreateTransactionRequest
         extends CoinPaymentsPostRequest<ResponseWrapper<CreateTransactionResponse>> {
 

--- a/src/main/java/org/brunocvcunha/coinpayments/requests/base/CoinPaymentsPostRequest.java
+++ b/src/main/java/org/brunocvcunha/coinpayments/requests/base/CoinPaymentsPostRequest.java
@@ -30,7 +30,7 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.util.EntityUtils;
 import org.brunocvcunha.coinpayments.CoinPaymentsConstants;
 
-import lombok.extern.log4j.Log4j;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * 
@@ -39,7 +39,7 @@ import lombok.extern.log4j.Log4j;
  */
 @Data
 @EqualsAndHashCode(callSuper = true)
-@Log4j
+@Slf4j
 public abstract class CoinPaymentsPostRequest<T> extends CoinPaymentsRequest<T> {
 
     @Override

--- a/src/main/java/org/brunocvcunha/coinpayments/requests/base/CoinPaymentsRequest.java
+++ b/src/main/java/org/brunocvcunha/coinpayments/requests/base/CoinPaymentsRequest.java
@@ -27,12 +27,12 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import lombok.extern.log4j.Log4j;
+import lombok.extern.slf4j.Slf4j;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @EqualsAndHashCode
-@Log4j
+@Slf4j
 public abstract class CoinPaymentsRequest<T> {
 
     @Getter

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    
+    <!-- Set WARN level for coinpayments package to match original log4j behavior -->
+    <logger name="org.brunocvcunha.coinpayments" level="WARN"/>
+    
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
## Summary

This PR addresses the failing Dependabot security update workflow by migrating from the insecure log4j 1.2.17 to a modern, secure logging framework.

## Background

The repository currently uses log4j 1.2.17, which:
- Reached end-of-life in 2015
- Has known security vulnerabilities
- Is causing Dependabot security updates to fail

## Changes

- **pom.xml**: Replace log4j 1.x with SLF4J 2.0.x + Logback 1.4.x
- **Source files**: Update imports from  to SLF4J's 
- **logback.xml**: Add configuration file for logging

## Testing

- All Java source files compile
- All existing logging functionality preserved

## Security Impact

Eliminates dependency on vulnerable end-of-life logging framework.

Fixes the failing workflow: https://github.com/bvolpato/coinpayments-java/actions/runs/17417881271